### PR TITLE
Make saving images lazy

### DIFF
--- a/Editor/Models/RSI/RsiItem.cs
+++ b/Editor/Models/RSI/RsiItem.cs
@@ -29,7 +29,12 @@ namespace Editor.Models.RSI
         
         public UpdateState WasModified(RsiState state)
         {
-            return _rsiUpdateStates[state.Name];
+            if (_rsiUpdateStates.TryGetValue(state.Name, out var wasModified)) 
+                return wasModified;
+            
+            // Assume the state is new and track it
+            _rsiUpdateStates.Add(state.Name, UpdateState.Edit);
+            return UpdateState.Edit;
         }
         
         public void LoadImage(int index, Image<Rgba32> image)

--- a/Editor/Models/RSI/RsiItem.cs
+++ b/Editor/Models/RSI/RsiItem.cs
@@ -1,4 +1,5 @@
-﻿using Importer.RSI;
+﻿using System.Collections.Generic;
+using Importer.RSI;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -9,12 +10,28 @@ namespace Editor.Models.RSI
         public RsiItem(Rsi? rsi = null)
         {
             Rsi = rsi ?? new Rsi();
+            foreach (var rsiState in Rsi.States)
+            {
+                _rsiUpdateStates[rsiState.Name] = UpdateState.None;
+            }
         }
 
         public Rsi Rsi { get; }
 
+        private Dictionary<string, UpdateState> _rsiUpdateStates = new();
+
         public RsiSize Size => Rsi.Size;
 
+        public void MarkAsUpdated(RsiState state, UpdateState updateState)
+        {
+            _rsiUpdateStates[state.Name] = updateState;
+        }
+        
+        public UpdateState WasModified(RsiState state)
+        {
+            return _rsiUpdateStates[state.Name];
+        }
+        
         public void LoadImage(int index, Image<Rgba32> image)
         {
             Rsi.States[index].LoadImage(image, Size);
@@ -23,11 +40,13 @@ namespace Editor.Models.RSI
         public void AddState(RsiImage image)
         {
             Rsi.States.Add(image.State);
+            _rsiUpdateStates.Add(image.State.Name, UpdateState.Edit);
         }
 
         public void InsertState(int index, RsiImage image)
         {
             Rsi.States.Insert(index, image.State);
+            _rsiUpdateStates.TryAdd(image.State.Name, UpdateState.Edit);
         }
 
         public void RemoveState(int index)
@@ -44,5 +63,11 @@ namespace Editor.Models.RSI
                 RemoveState(index);
             }
         }
+    }
+    
+    public enum UpdateState : byte
+    {
+        None,
+        Edit
     }
 }

--- a/Editor/ViewModels/MainWindowViewModel.cs
+++ b/Editor/ViewModels/MainWindowViewModel.cs
@@ -158,7 +158,30 @@ namespace Editor.ViewModels
                 IgnoreNullValues = true
             };
 
-            await rsi.Item.Rsi.SaveToFolder(rsi.SaveFolder, options);
+            // Lazy version of 
+            Directory.CreateDirectory(rsi.SaveFolder);
+
+            await SaveImagesLazy(rsi, rsi.SaveFolder);
+            await rsi.Item.Rsi.SaveRsiToFolder(rsi.SaveFolder, options);
+        }
+
+        private async Task SaveImagesLazy(RsiItemViewModel rsi, string? rsiFolder)
+        {
+            var rsiItem = rsi.Item.Rsi;
+            foreach (var state in rsiItem.States)
+            {
+                switch (rsi.Item.WasModified(state))
+                {
+                    case UpdateState.None:
+                        break;
+                    default:
+                        var image = state.GetFullImage(rsiItem.Size);
+                        var path = $"{rsiFolder}{Path.DirectorySeparatorChar}{state.Name}.png";
+
+                        await image.SaveAsPngAsync(path);
+                        break;
+                }
+            }
         }
 
         private async Task SaveRsi(RsiItemViewModel rsi)


### PR DESCRIPTION
# This PR makes image saving lazy
Relates to #24

Images are now lazily saved i.e. not updated if they weren't touched at all.
This should prevent any changes when the file wasn't actually altered. I hope to figure out a way to detect renames.

