### PR TITLE
Add multiple selection

### DIFF
--- a/Editor/ViewModels/MainWindowViewModel.cs
+++ b/Editor/ViewModels/MainWindowViewModel.cs
@@ -313,7 +313,7 @@ namespace Editor.ViewModels
             if (CurrentOpenRsi != null &&
                 CurrentOpenRsi.TryRestore(out var selected))
             {
-                CurrentOpenRsi.SelectedState = selected;
+                CurrentOpenRsi.SelectedStates.Add(selected);
             }
         }
 
@@ -328,9 +328,12 @@ namespace Editor.ViewModels
 
         public void Directions(DirectionType directions)
         {
-            if (CurrentOpenRsi?.SelectedState != null)
+            if (CurrentOpenRsi != null && CurrentOpenRsi.SelectedStates.Count != 0)
             {
-                CurrentOpenRsi.SelectedState.Image.State.Directions = directions;
+                foreach (var state in CurrentOpenRsi.SelectedStates)
+                {
+                    state.Image.State.Directions = directions;
+                }
             }
         }
 
@@ -364,7 +367,7 @@ namespace Editor.ViewModels
 
         public void Delete()
         {
-            CurrentOpenRsi?.DeleteSelectedState();
+            CurrentOpenRsi?.DeleteSelectedStates();
         }
     }
 }

--- a/Editor/ViewModels/RsiItemViewModel.cs
+++ b/Editor/ViewModels/RsiItemViewModel.cs
@@ -296,10 +296,7 @@ namespace Editor.ViewModels
 
         public async Task ExportPng()
         {
-            if (SelectedState == null)
-                return;
-
-            var png = SelectedState.Image.State.GetFullImage(Item.Size);
+            var png = SelectedStates[0].Image.State.GetFullImage(Item.Size);
             
             await ExportPngInteraction.Handle(png);
         }

--- a/Editor/Views/RsiItemView.axaml
+++ b/Editor/Views/RsiItemView.axaml
@@ -10,12 +10,12 @@
             <Panel Height="120">
                 <views:RsiFramesView Name="Frames" Content="{Binding Frames}"/>
             </Panel>
-            <ListBox Name="States" Items="{Binding States}" SelectedItem="{Binding SelectedState}" Height="480">
+            <ListBox Name="States" SelectionMode="Multiple" Items="{Binding States}" SelectedItems="{Binding SelectedStates}" Height="480">
                 <ListBox.ContextMenu>
                     <ContextMenu>
                         <MenuItem Header="Add new state" Command="{Binding CreateNewState}"/>
                         <MenuItem Header="Import PNG" Command="{Binding ImportPng}"/>
-                        <MenuItem Header="Delete" IsEnabled="{Binding HasStateSelected}" Command="{Binding DeleteSelectedState}" InputGesture="Delete" />
+                        <MenuItem Header="Delete" IsEnabled="{Binding HasStateSelected}" Command="{Binding DeleteSelectedStates}" InputGesture="Delete" />
                     </ContextMenu>
                 </ListBox.ContextMenu>
                 <ListBox.ItemsPanel>

--- a/Editor/Views/RsiItemView.axaml
+++ b/Editor/Views/RsiItemView.axaml
@@ -14,7 +14,7 @@
                 <ListBox.ContextMenu>
                     <ContextMenu>
                         <MenuItem Header="Add new state" Command="{Binding CreateNewState}"/>
-                        <MenuItem Header="Import PNG" Command="{Binding ImportPng}"/>
+                        <MenuItem Header="Import PNG" IsEnabled="{Binding HasOneStateSelected}" Command="{Binding ImportPng}"/>
                         <MenuItem Header="Export PNG" IsEnabled="{Binding HasOneStateSelected}" Command="{Binding ExportPng}"/>
                         <MenuItem Header="Delete" IsEnabled="{Binding HasStateSelected}" Command="{Binding DeleteSelectedStates}" InputGesture="Delete" />
                     </ContextMenu>

--- a/Editor/Views/RsiItemView.axaml.cs
+++ b/Editor/Views/RsiItemView.axaml.cs
@@ -25,11 +25,16 @@ namespace Editor.Views
             this.WhenActivated(d =>
             {
                 d.Add(this.WhenAnyValue(x => x.ViewModel)
-                    .Subscribe(new AnonymousObserver<RsiItemViewModel?>(newVm =>
+                    .Subscribe(new AnonymousObserver<RsiItemViewModel?>(vm =>
                     {
-                        if (newVm != null)
+                        if (vm != null)
                         {
-                            AddDisposables(d, newVm);
+                            d.Add(vm.ImportPngInteraction.RegisterHandler(ImportPng));
+                            d.Add(vm.ExportPngInteraction.RegisterHandler(ExportPng));
+                            d.Add(vm.ErrorDialog.RegisterHandler(ShowError));
+                            d.Add(vm.CloseInteraction.RegisterHandler(Close));
+                            d.Add(vm.States.Subscribe(new AnonymousObserver<RsiStateViewModel>(s => d.Add(s.Image.Preview))));
+                            d.Add(vm);
                         }
                     })));
             });
@@ -38,16 +43,6 @@ namespace Editor.Views
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-        }
-
-        private void AddDisposables(CompositeDisposable d, RsiItemViewModel vm)
-        {
-            d.Add(vm.ImportPngInteraction.RegisterHandler(ImportPng));
-            d.Add(vm.ExportPngInteraction.RegisterHandler(ExportPng));
-            d.Add(vm.ErrorDialog.RegisterHandler(ShowError));
-            d.Add(vm.CloseInteraction.RegisterHandler(Close));
-            d.Add(vm.States.Subscribe(new AnonymousObserver<RsiStateViewModel>(s => d.Add(s.Image.Preview))));
-            d.Add(vm);
         }
 
         private void ShowError(InteractionContext<ErrorWindowViewModel, Unit> interaction)

--- a/Editor/Views/RsiItemView.axaml.cs
+++ b/Editor/Views/RsiItemView.axaml.cs
@@ -91,7 +91,7 @@ namespace Editor.Views
             var dialog = new SaveFileDialog
             {
                 DefaultExtension = "png",
-                InitialFileName = ViewModel?.SelectedState?.Image.State.Name ?? string.Empty,
+                InitialFileName = ViewModel?.SelectedStates[0].Image.State.Name ?? string.Empty,
             };
             
             var args = new SaveFileDialogEvent(dialog, interaction.Input) { RoutedEvent = MainWindow.SaveFileEvent };

--- a/Editor/Views/RsiItemView.axaml.cs
+++ b/Editor/Views/RsiItemView.axaml.cs
@@ -24,9 +24,6 @@ namespace Editor.Views
 
             this.WhenActivated(d =>
             {
-                var vm = ViewModel!;
-
-                AddDisposables(d, vm);
                 d.Add(this.WhenAnyValue(x => x.ViewModel)
                     .Subscribe(new AnonymousObserver<RsiItemViewModel?>(newVm =>
                     {


### PR DESCRIPTION
Ctrl+click to select one more, shift+click to select all up to. Same controls as anything else

- Fixes a double subscription bug causing the ExportPng window to show up twice
- Adds multiple selection--delete will delete all selected, exportPNG/importPNG require only 1 to be selected